### PR TITLE
Upgrade mongo-scala-driver_2.12 from 4.2.3 to 4.2.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -116,8 +116,7 @@ version.org.apache.spark..spark-mllib_2.12=3.1.1
 
 version.org.apache.spark..spark-sql_2.12=3.1.1
 
-version.org.mongodb.scala..mongo-scala-driver_2.12=4.2.3
-##                                     # available=4.2.2
+version.org.mongodb.scala..mongo-scala-driver_2.12=4.2.2
 ##                                     # available=4.3.0-beta1
 
 version.org.scala-lang.modules..scala-swing_2.12=3.0.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.